### PR TITLE
LKL-2162 Add setup-uv self-updating action

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -1,0 +1,30 @@
+name: Sync Fork with Upstream
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Forked Repository
+        uses: actions/checkout@v4
+        with:
+            fetch-tags: true
+            token: ${{ secrets.SYNC_FORK_TOKEN }}
+
+      - name: Configure comitter
+        run: |
+          git config --global user.email "mkirkeng@leukeleu.nl"
+          git config --global user.name "Mathias Kirkeng"
+
+      - name: Add Upstream Remote
+        run: git remote add upstream https://github.com/astral-sh/setup-uv.git
+
+      - name: Fetch Upstream Changes
+        run: git fetch --prune --all --verbose
+
+      - name: Push changes to origin
+        run: |
+          git push origin refs/heads/main --tags --verbose

--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -16,8 +16,8 @@ jobs:
 
       - name: Configure comitter
         run: |
-          git config --global user.email "mkirkeng@leukeleu.nl"
-          git config --global user.name "Mathias Kirkeng"
+          git config --global user.email "deployer@leukeleu.nl"
+          git config --global user.name "Leukeleu bot"
 
       - name: Add Upstream Remote
         run: git remote add upstream https://github.com/astral-sh/setup-uv.git

--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -23,8 +23,7 @@ jobs:
         run: git remote add upstream https://github.com/astral-sh/setup-uv.git
 
       - name: Fetch Upstream Changes
-        run: git fetch --prune --all --verbose
+        run: git fetch upstream --prune --tags --verbose
 
       - name: Push changes to origin
-        run: |
-          git push origin refs/heads/main --tags --verbose
+        run: git push origin --tags --verbose


### PR DESCRIPTION
Added workflow to sync this fork with the upstream repo once per day. This also pulls in all tags so we can use this action like any other: `uses: leukeleu/setup-uv@v6`.

We will need a PAT in the repository secrets (called `SYNC_FORK_TOKEN` for now) with read/write permissions for the contents of this repo and read/write for workflows as well (because workflows might be updated on the upstream repo and when we pull those in they will be changed here as well).

Edit: I did also test dependabot and it will happily open PRs to update the version of our forked action.